### PR TITLE
alsa-gobject: implement Send trait for GLib boxed objects

### DIFF
--- a/alsaseq/src/auto/addr.rs
+++ b/alsaseq/src/auto/addr.rs
@@ -58,3 +58,5 @@ impl PartialEq for Addr {
 }
 
 impl Eq for Addr {}
+
+unsafe impl Send for Addr {}

--- a/alsaseq/src/auto/event_data_connect.rs
+++ b/alsaseq/src/auto/event_data_connect.rs
@@ -31,3 +31,5 @@ impl EventDataConnect {
         }
     }
 }
+
+unsafe impl Send for EventDataConnect {}

--- a/alsaseq/src/auto/event_data_ctl.rs
+++ b/alsaseq/src/auto/event_data_ctl.rs
@@ -64,3 +64,5 @@ impl EventDataCtl {
         }
     }
 }
+
+unsafe impl Send for EventDataCtl {}

--- a/alsaseq/src/auto/event_data_note.rs
+++ b/alsaseq/src/auto/event_data_note.rs
@@ -94,3 +94,5 @@ impl EventDataNote {
         }
     }
 }
+
+unsafe impl Send for EventDataNote {}

--- a/alsaseq/src/auto/event_data_queue.rs
+++ b/alsaseq/src/auto/event_data_queue.rs
@@ -71,3 +71,5 @@ impl EventDataQueue {
         }
     }
 }
+
+unsafe impl Send for EventDataQueue {}

--- a/alsaseq/src/auto/event_data_result.rs
+++ b/alsaseq/src/auto/event_data_result.rs
@@ -50,3 +50,5 @@ impl EventDataResult {
         }
     }
 }
+
+unsafe impl Send for EventDataResult {}

--- a/alsaseq/src/auto/queue_timer_data_alsa.rs
+++ b/alsaseq/src/auto/queue_timer_data_alsa.rs
@@ -34,3 +34,5 @@ impl QueueTimerDataAlsa {
         }
     }
 }
+
+unsafe impl Send for QueueTimerDataAlsa {}

--- a/alsaseq/src/auto/remove_filter.rs
+++ b/alsaseq/src/auto/remove_filter.rs
@@ -79,3 +79,5 @@ impl RemoveFilter {
         }
     }
 }
+
+unsafe impl Send for RemoveFilter {}

--- a/alsaseq/src/tstamp.rs
+++ b/alsaseq/src/tstamp.rs
@@ -46,6 +46,8 @@ impl Tstamp {
     }
 }
 
+unsafe impl Send for Tstamp {}
+
 #[test]
 fn test_manual_bindings() {
     use EventCntr;

--- a/alsatimer/src/auto/device_id.rs
+++ b/alsatimer/src/auto/device_id.rs
@@ -62,3 +62,5 @@ impl DeviceId {
         }
     }
 }
+
+unsafe impl Send for DeviceId {}

--- a/alsatimer/src/auto/event_data_tick.rs
+++ b/alsatimer/src/auto/event_data_tick.rs
@@ -37,3 +37,5 @@ impl EventDataTick {
         }
     }
 }
+
+unsafe impl Send for EventDataTick {}

--- a/alsatimer/src/auto/event_data_tstamp.rs
+++ b/alsatimer/src/auto/event_data_tstamp.rs
@@ -38,3 +38,5 @@ impl EventDataTstamp {
         }
     }
 }
+
+unsafe impl Send for EventDataTstamp {}

--- a/alsatimer/src/event.rs
+++ b/alsatimer/src/event.rs
@@ -45,3 +45,5 @@ impl Event {
         }
     }
 }
+
+unsafe impl Send for Event {}

--- a/conf/gir-alsaseq.toml
+++ b/conf/gir-alsaseq.toml
@@ -33,15 +33,10 @@ generate = [
     "ALSASeq.QueueTimerType",
     "ALSASeq.RemoveFilterFlag",
     "ALSASeq.SystemInfo",
-    "ALSASeq.Addr",
     "ALSASeq.PortInfo",
     "ALSASeq.ClientPool",
-    "ALSASeq.EventDataResult",
-    "ALSASeq.EventDataNote",
-    "ALSASeq.EventDataCtl",
     "ALSASeq.SubscribeData",
     "ALSASeq.QueueInfo",
-    "ALSASeq.RemoveFilter",
 ]
 
 [[object]]
@@ -74,6 +69,7 @@ manual_traits = ["UserClientExtManual"]
 [[object]]
 name = "ALSASeq.EventDataConnect"
 status = "generate"
+concurrency = "send"
     [[object.function]]
     pattern = "get_src"
     ignore = true
@@ -82,8 +78,24 @@ status = "generate"
     ignore = true
 
 [[object]]
+name = "ALSASeq.Addr"
+status = "generate"
+concurrency = "send"
+
+[[object]]
+name = "ALSASeq.EventDataCtl"
+status = "generate"
+concurrency = "send"
+
+[[object]]
+name = "ALSASeq.EventDataNote"
+status = "generate"
+concurrency = "send"
+
+[[object]]
 name = "ALSASeq.EventDataQueue"
 status = "generate"
+concurrency = "send"
     [[object.function]]
     pattern = "get_byte_param"
     ignore = true
@@ -105,6 +117,11 @@ status = "generate"
     [[object.function]]
     pattern = "get_tstamp_param"
     ignore = true
+
+[[object]]
+name = "ALSASeq.EventDataResult"
+status = "generate"
+concurrency = "send"
 
 [[object]]
 name = "ALSASeq.ClientInfo"
@@ -147,6 +164,7 @@ manual_traits = ["QueueTimerExtManual"]
 [[object]]
 name = "ALSASeq.QueueTimerDataAlsa"
 status = "generate"
+concurrency = "send"
     [[object.function]]
     pattern = "get_device_id"
     ignore = true
@@ -203,3 +221,8 @@ manual_traits = ["EventCntrExtManual"]
     [[object.function]]
     pattern = "set_quadlet_data"
     ignore = true
+
+[[object]]
+name = "ALSASeq.RemoveFilter"
+status = "generate"
+concurrency = "send"

--- a/conf/gir-alsatimer.toml
+++ b/conf/gir-alsatimer.toml
@@ -22,12 +22,10 @@ generate = [
     "ALSATimer.InstanceParamFlag",
     "ALSATimer.EventType",
     "ALSATimer.EventDataType",
-    "ALSATimer.DeviceId",
     "ALSATimer.DeviceInfo",
     "ALSATimer.DeviceStatus",
     "ALSATimer.DeviceParams",
     "ALSATimer.InstanceInfo",
-    "ALSATimer.EventDataTick",
 ]
 
 [[object]]
@@ -82,8 +80,19 @@ manual_traits = ["InstanceStatusExtManual"]
     ignore = true
 
 [[object]]
+name = "ALSATimer.DeviceId"
+status = "generate"
+concurrency = "send"
+
+[[object]]
+name = "ALSATimer.EventDataTick"
+status = "generate"
+concurrency = "send"
+
+[[object]]
 name = "ALSATimer.EventDataTstamp"
 status = "generate"
+concurrency = "send"
     [[object.function]]
     name = "get_tstamp"
     ignore = true


### PR DESCRIPTION
This patchset fixes issue #1 .

In alsa-gobject-rs, all types for boxed-object have own storage and no reference to the other objects. They are safe to move between threads and Send trait is available for them.

The affected boxed objects are enumerated in the below list:

    alsaseq::Addr
    alsaseq::EventDataConnect
    alsaseq::EventDataCtl
    alsaseq::EventDataNote
    alsaseq::EventDataQueue
    alsaseq::EventDataResult
    alsaseq::QueueTimerDataAlsa
    alsaseq::RemoveFilter
    alsaseq::Tstamp
    alsatimer::DeviceId
    alsatimer::EventDataTick
    alsatimer::EventDataTstamp
    alsatimer::Event

This patchset adds some configurations for gtk-rs/gir to add implementation of Send trait for the above.