### PR TITLE
Use flexible crate version dependency and workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+members = [
+    "alsactl-sys",
+    "alsactl",
+    "alsahwdep-sys",
+    "alsahwdep",
+    "alsatimer-sys",
+    "alsatimer",
+    "alsaseq-sys",
+    "alsaseq",
+    "alsarawmidi-sys",
+    "alsarawmidi",
+]
+
+default-members = [
+    "alsactl",
+    "alsahwdep",
+    "alsatimer",
+    "alsaseq",
+    "alsarawmidi",
+]

--- a/alsactl-sys/Cargo.toml
+++ b/alsactl-sys/Cargo.toml
@@ -12,11 +12,8 @@ name = "alsactl_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/alsactl/Cargo.toml
+++ b/alsactl/Cargo.toml
@@ -9,9 +9,10 @@ name = "alsactl"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 alsactl-sys = { path = "../alsactl-sys" }
 
 [dev-dependencies]

--- a/alsactl/Cargo.toml
+++ b/alsactl/Cargo.toml
@@ -13,7 +13,8 @@ bitflags = "1.0"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-alsactl-sys = { path = "../alsactl-sys" }
+
+alsactl-sys = {path = "../alsactl-sys", version = "0.0" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/alsahwdep-sys/Cargo.toml
+++ b/alsahwdep-sys/Cargo.toml
@@ -12,11 +12,8 @@ name = "alsahwdep_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/alsahwdep/Cargo.toml
+++ b/alsahwdep/Cargo.toml
@@ -13,7 +13,8 @@ bitflags = "1.0"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-alsahwdep-sys = { path = "../alsahwdep-sys" }
+
+alsahwdep-sys = { path = "../alsahwdep-sys", version = "0.0" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/alsahwdep/Cargo.toml
+++ b/alsahwdep/Cargo.toml
@@ -9,9 +9,10 @@ name = "alsahwdep"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 alsahwdep-sys = { path = "../alsahwdep-sys" }
 
 [dev-dependencies]

--- a/alsarawmidi-sys/Cargo.toml
+++ b/alsarawmidi-sys/Cargo.toml
@@ -12,11 +12,8 @@ name = "alsarawmidi_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/alsarawmidi/Cargo.toml
+++ b/alsarawmidi/Cargo.toml
@@ -13,7 +13,8 @@ bitflags = "1.0"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-alsarawmidi-sys = { path = "../alsarawmidi-sys" }
+
+alsarawmidi-sys = { path = "../alsarawmidi-sys", version = "0.0" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/alsarawmidi/Cargo.toml
+++ b/alsarawmidi/Cargo.toml
@@ -9,9 +9,10 @@ name = "alsarawmidi"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 alsarawmidi-sys = { path = "../alsarawmidi-sys" }
 
 [dev-dependencies]

--- a/alsaseq-sys/Cargo.toml
+++ b/alsaseq-sys/Cargo.toml
@@ -15,8 +15,7 @@ libc = "0.2"
 glib-sys = "0.10"
 gobject-sys = "0.10"
 
-[dependencies.alsatimer-sys]
-path = "../alsatimer-sys"
+alsatimer-sys = { path = "../alsatimer-sys", version = "0.0"}
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/alsaseq-sys/Cargo.toml
+++ b/alsaseq-sys/Cargo.toml
@@ -12,11 +12,8 @@ name = "alsaseq_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [dependencies.alsatimer-sys]
 path = "../alsatimer-sys"

--- a/alsaseq/Cargo.toml
+++ b/alsaseq/Cargo.toml
@@ -9,9 +9,10 @@ name = "alsaseq"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 alsatimer-sys = { path = "../alsatimer-sys" }
 alsaseq-sys = { path = "../alsaseq-sys" }
 alsatimer = { path = "../alsatimer" }

--- a/alsaseq/Cargo.toml
+++ b/alsaseq/Cargo.toml
@@ -13,9 +13,10 @@ bitflags = "1.0"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-alsatimer-sys = { path = "../alsatimer-sys" }
-alsaseq-sys = { path = "../alsaseq-sys" }
-alsatimer = { path = "../alsatimer" }
+
+alsatimer-sys = { path = "../alsatimer-sys", version = "0.0" }
+alsaseq-sys = { path = "../alsaseq-sys", version = "0.0" }
+alsatimer = { path = "../alsatimer", version = "0.0" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/alsatimer-sys/Cargo.toml
+++ b/alsatimer-sys/Cargo.toml
@@ -12,11 +12,8 @@ name = "alsatimer_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/alsatimer/Cargo.toml
+++ b/alsatimer/Cargo.toml
@@ -13,7 +13,8 @@ bitflags = "1.0"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-alsatimer-sys = { path = "../alsatimer-sys" }
+
+alsatimer-sys = { path = "../alsatimer-sys", version = "0.0" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/alsatimer/Cargo.toml
+++ b/alsatimer/Cargo.toml
@@ -9,9 +9,10 @@ name = "alsatimer"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 alsatimer-sys = { path = "../alsatimer-sys" }
 
 [dev-dependencies]


### PR DESCRIPTION
In v0.1.0 release, all of included crates have explicit version dependencies to some crates, mainly from gtk-rs project. This is worse since users cannot use updated version of the crates.

Additionally, Cargo has a feature called as 'Workspace'. This is usefull in the case that several crates are under controlled.

This patchset uses flexible crate version dependency and workspace.